### PR TITLE
Add cors support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,6 +2245,15 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
+        "cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "requires": {
+                "object-assign": "^4",
+                "vary": "^1"
+            }
+        },
         "cpx2": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/cpx2/-/cpx2-2.0.0.tgz",
@@ -5538,6 +5547,11 @@
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "@overnightjs/core": "^1.7.5",
         "@overnightjs/jwt": "^1.2.0",
         "@overnightjs/logger": "^1.2.0",
+        "cors": "^2.8.5",
         "cron": "^1.8.2",
         "dotenv": "^8.2.0",
         "env-var": "^6.3.0",

--- a/src/controllers/ApiController.ts
+++ b/src/controllers/ApiController.ts
@@ -4,9 +4,11 @@
 import {
     ChildControllers,
     ClassErrorMiddleware,
+    ClassMiddleware,
     ClassOptions,
     Controller
 } from '@overnightjs/core';
+import cors from 'cors';
 
 import { AuthorizationController } from './AuthorizationController';
 import { DownloadController } from './DownloadController';
@@ -22,6 +24,7 @@ import { ParticipantController } from './ParticipantController';
  */
 @Controller('api')
 @ClassOptions({ mergeParams: true })
+@ClassMiddleware(cors())
 @ClassErrorMiddleware((err, req, res) => {
     if (err.name === 'UnauthorizedError') {
         res.status(401).send({ error: 'invalid_subjectid' });


### PR DESCRIPTION
This is the MVP version of adding CORS support to the backend. There is potential to make this more elaborate, e.g. configure which origins are whitelisted, but this small change will already allow web frontends to use the backend without having to fork it, and no additional config overhead is added.