### PR TITLE
Adding information on how to generate and embed certificate

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,3 +19,5 @@ TZ = 'Europe/Amsterdam'
 # encryption keys
 COMPASS_PUBLIC_KEY='-----BEGIN PUBLIC KEY-----\nMII ... \n ... \n-----END PUBLIC KEY-----'
 COMPASS_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----\nMII ... \n ... =\n-----END PRIVATE KEY-----'
+
+COMPASS_RECIPIENT_CERTIFICATE='-----BEGIN CERTIFICATE-----\nMII .... \n ... \n-----END CERTIFICATE-----'

--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ $ openssl rsa -pubout -in private_key.pem -out public_key.pem
 
 ==== Generating certificate
 
-To submit the private key to the client, a certificate must be created.
+To submit the public key to the client, a certificate must be created.
 To create a self-signed certificate, which will be valid for 1 year, use the following command:
 
 [source,bash]

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,20 @@ $ openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:4
 $ openssl rsa -pubout -in private_key.pem -out public_key.pem
 ----
 
+==== Generating certificate
+
+To submit the private key to the client, a certificate must be created.
+To create a self-signed certificate, which will be valid for 1 year, use the following command:
+
+[source,bash]
+----
+$ openssl req -x509 -days 365 -new -out self-signed-certificate.pem -key private_key.pem
+----
+
+The certificate must be put in the .env file. If no certificate is provided, the native app will default to a built-in
+one (defined in src/config/appConfig.js).
+
+
 === Scripts
 
 ====  npm run start


### PR DESCRIPTION
To be able to encrypt the submitted QuestionnaireResponses, besides creating a key pair, I had to wrap the public key as self-signed certificate and embed it into the .env file.

Maybe I missed something or I did something else wrong, so any feedback on this is appreciated.