### PR TITLE
Adding enpoint to retrieve Questionnaire by url/version

### DIFF
--- a/src/assets/openapi.yaml
+++ b/src/assets/openapi.yaml
@@ -21,6 +21,39 @@ tags:
     - name: subjectIdentities
       description: API to manage subjectIdentities based on orscf standard
 paths:
+    '/questionnaire':
+        get:
+            tags:
+                - questionnaire
+            summary: Get a specific questionnaire by version and url
+            operationId: getQuestionnaireByUrlAndVersion
+            parameters:
+                -   name: url
+                    in: query
+                    description: Questionnaire.url value
+                    schema:
+                        type: string
+                    required: true
+                -   name: version
+                    in: query
+                    description: Questionnaire.version value
+                    schema:
+                        type: string
+                    required: true
+            responses:
+                '200':
+                    description: A FHIR Questionnaire as JSON
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Questionnaire'
+                '401':
+                    $ref: '#/components/responses/401NotAuthenticated'
+                '500':
+                    description: If Questionnaire could not be found or multiple Questionnaires match
+                    $ref: '#/components/responses/500ServerError'
+            security:
+                -   Bearer: [ ]
     '/questionnaire/{questionnaireId}':
         get:
             tags:
@@ -248,7 +281,7 @@ paths:
                 '401':
                     $ref: '#/components/responses/401NotAuthenticated'
                 '409':
-                    $ref: '#/components/responses/409Conflict'    
+                    $ref: '#/components/responses/409Conflict'
                 '500':
                     $ref: '#/components/responses/500ServerError'
 components:

--- a/src/controllers/QuestionnaireController.ts
+++ b/src/controllers/QuestionnaireController.ts
@@ -54,4 +54,32 @@ export class QuestionnaireController {
             }
         );
     }
+
+    /**
+     * Provide the questionnaire data for the requested questionnaire url and version
+     *
+     * @param {ISecureRequest} req
+     * @param {Response} res
+     * @memberof QuestionnaireController
+     */
+    @Get('')
+    @Middleware([AuthorizationController.checkApiUserLogin])
+    public async getQuestionnaireByUrlAndVersion(req: ISecureRequest, res: Response) {
+        const url = req.query.url.toString();
+        const version = req.query.version.toString();
+
+        if (!url || !version) {
+            res.status(400).end();
+        }
+        this.questionnaireModel.getQuestionnaireByUrlAndVersion(url, version).then(
+            (resp) => res.status(200).json(resp),
+            (err) => {
+                if (err.response) {
+                    res.status(err.response.status).end();
+                } else {
+                    res.status(500).end();
+                }
+            }
+        );
+    }
 }

--- a/src/models/QuestionnaireModel.ts
+++ b/src/models/QuestionnaireModel.ts
@@ -69,4 +69,37 @@ export class QuestionnaireModel {
             dbClient.release();
         }
     }
+
+    /**
+     * Retrieve the questionnaire with the requested url and version. Do not create a log
+     *
+     * @param {string} url Questionnaire.url
+     * @param {string} version Questionnaire.version
+     * @return {*}  {Promise<string>}
+     * @memberof QuestionnaireModel
+     */
+    public async getQuestionnaireByUrlAndVersion(url: string, version: string): Promise<string> {
+        // note: we don't try/catch this because if connecting throws an exception
+        // we don't need to dispose the client (it will be undefined)
+        const dbClient = await DB.getPool().connect();
+
+        try {
+            const res = await dbClient.query(
+                "select body from questionnaires where json_extract_path_text(body, 'url') = $1 and json_extract_path_text(body, 'version') = $2",
+                [url, version]
+            );
+            if (res.rows.length === 0) {
+                throw new Error('questionnaire_not_found');
+            } else if (res.rows.length > 1) {
+                throw new Error('questionnaire_url_and_version_not_unique');
+            } else {
+                return res.rows[0].body;
+            }
+        } catch (e) {
+            Logger.Err(e);
+            throw e;
+        } finally {
+            dbClient.release();
+        }
+    }
 }

--- a/src/models/SubjectIdentitiesModel.ts
+++ b/src/models/SubjectIdentitiesModel.ts
@@ -6,7 +6,6 @@ import { Logger } from '@overnightjs/logger';
 import DB from '../server/DB';
 
 export class SubjectIdentitiesModel {
-
     /**
      * Verify if participant exists in database.
      * @param subjectID The participant id


### PR DESCRIPTION
To create a FHIR Bundle suited for the D4L gecco conformity checker, I need a way to retrieve the original Questionnaire from the server. Since QuestionnaireResponse.questionnaire contains Questionnaire.url and Questionnaire.version, we need another way to retrieve the Questionnaire not by id, but by url and version. 

In theory, one could manually add the Questionnaires to the interface component, but when looking at the GMDS tutorial, I wouldn't recommend bathering the user with copying the Questionnaire to two places.

For the moment, I protected this new endpoint is protected with the API key. It is up to discussion if the Questionnaires are really this worthy of protection.