### PR TITLE
fix securityService test

### DIFF
--- a/tests/services/SecurityService.test.ts
+++ b/tests/services/SecurityService.test.ts
@@ -12,11 +12,11 @@ describe('signing', () => {
     });
 
     it('signAndVerify', () => {
-        const value = { name: 'KEY', sound: 'VALUE' };
-        const newSign = SecurityService.sign({ key: value });
-        SecurityService.verifyJWS(newSign);
         let result: boolean;
+        let newSign: string;
+        const value = { name: 'KEY', sound: 'VALUE' };
         try {
+            newSign = SecurityService.sign({ key: value });
             SecurityService.verifyJWS(newSign);
             result = true;
         } catch (err) {


### PR DESCRIPTION
With this pull request the test for the security service is modified so that if the signing fails and throws an error this error also gets caught and the test then fails because the result is not the expected one and _not_ because test itself fails due to an uncaught error.

In the process a redundant duplicate call of SecurityService.verifyJWS() is removed.