### PR TITLE
Replace download functionality

### DIFF
--- a/db/migration/V001__Setup_Tables.sql
+++ b/db/migration/V001__Setup_Tables.sql
@@ -37,6 +37,7 @@ CREATE TABLE queue
     encrypted_resp text NOT NULL,
     date_sent timestamp without time zone NOT NULL,
     date_received timestamp without time zone NOT NULL,
+    downloaded boolean DEFAULT false,
     CONSTRAINT queue_pkey PRIMARY KEY (id)
 );
 

--- a/src/assets/openapi.yaml
+++ b/src/assets/openapi.yaml
@@ -199,25 +199,25 @@ paths:
                     description: Page query parameter set wrong
                 '500':
                     $ref: '#/components/responses/500ServerError'
-        delete:
+        put:
             tags:
                 - download
-            summary: Delete given IDs from queue
+            summary: Mark entries with given IDs as downloaded
             requestBody:
-                description: UUIDs of CTransferList to be deleted
+                description: UUIDs of CTransferList to be updated
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/DeleteUUIDsParam'
+                            $ref: '#/components/schemas/UpdateUUIDsParam'
             security:
                 - DownloadAuthentication: []
             responses:
                 '200':
-                    description: Deleted row count
+                    description: Updated row count
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/DeletedRowCount'
+                                $ref: '#/components/schemas/UpdatedRowCount'
                 '500':
                     $ref: '#/components/responses/500ServerError'
     '/subjectIdentities/addNew':
@@ -248,7 +248,7 @@ paths:
                 '401':
                     $ref: '#/components/responses/401NotAuthenticated'
                 '409':
-                    $ref: '#/components/responses/409Conflict'    
+                    $ref: '#/components/responses/409Conflict'
                 '500':
                     $ref: '#/components/responses/500ServerError'
 components:
@@ -266,16 +266,16 @@ components:
                     type: string
                     description: >-
                         'RSA-SHA256' Signature of object containing UUID, Subject ID, encrypted questionnaire response, dispatch date, reception date.'
-        DeleteUUIDsParam:
+        UpdateUUIDsParam:
             type: array
             items:
                 type: string
-                description: UUID of CTransfer to be deleted.
+                description: UUID of CTransfer to be updated.
                 example: 534772d7-b62d-4050-ab2f-f052933c325f
-        DeletedRowCount:
+        UpdatedRowCount:
             type: object
             properties:
-                deletedRowCount:
+                updatedRowCount:
                     type: number
         LoginRequest:
             type: object
@@ -288,7 +288,7 @@ components:
                 encrypted_key:
                     type: string
                     description: >
-                        Encrypt random AES key with backends public key (RSA-AES-256-CBC
+                        Encrypt random AES key with the backend's public key (RSA-AES-256-CBC
                         Encryption)
                 iv:
                     type: string
@@ -326,10 +326,10 @@ components:
                         - on-study
                         - off-study
                     description: Marks if subject is participating in the study
-                general_study_end_date: 
+                general_study_end_date:
                     type: date
                     description: End date of study that subject is/was participating in
-                personal_study_end_date: 
+                personal_study_end_date:
                     type: date
                     description: Individual end date of study that subject is/was participating in
         Health:

--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -2,12 +2,10 @@
  * Copyright (c) 2021, IBM Deutschland GmbH
  */
 
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-
 import { Request, Response } from 'express';
 import jwt from 'express-jwt';
 
-import { ClassMiddleware, Controller, Delete, Get } from '@overnightjs/core';
+import { ClassMiddleware, Controller, Get, Put } from '@overnightjs/core';
 import Logger from 'jet-logger';
 
 import { CTransfer } from '../types/CTransfer';
@@ -48,7 +46,7 @@ export class DownloadController {
      * @memberof DownloadController
      */
     @Get()
-    public async getAvailableDataFromQueue(req: Request, resp: Response) {
+    public async getAvailableDataFromQueue(req: Request, resp: Response): Promise<Response> {
         try {
             const page: number = req.query.page ? parseInt(req.query.page.toString(), 10) : 1;
             if (page < 1) {
@@ -95,21 +93,21 @@ export class DownloadController {
     }
 
     /**
-     * Delete study data from the download queue.
+     * Mark queue entries as downloaded
      *
      * @param {Request} req
      * @param {Response} resp
      * @return {*}
      * @memberof DownloadController
      */
-    @Delete()
-    public async deleteDataFromQueue(req: Request, resp: Response) {
+    @Put()
+    public async markAsDownloaded(req: Request, resp: Response): Promise<Response> {
         try {
             if (!Array.isArray(req.body)) {
                 return resp.sendStatus(400);
             }
-            const deletedRowCount = await this.queueModel.deleteQueueDataByIdArray(req.body);
-            return resp.status(200).send({ deletedRowCount });
+            const updatedRowCount = await this.queueModel.markAsDownloaded(req.body);
+            return resp.status(200).send({ updatedRowCount: updatedRowCount });
         } catch (err) {
             Logger.Err(err, true);
             return resp.sendStatus(500);

--- a/src/models/QueueModel.ts
+++ b/src/models/QueueModel.ts
@@ -33,7 +33,7 @@ export class QueueModel {
         try {
             const pool: Pool = DB.getPool();
             const res = await pool.query(
-                'SELECT * FROM queue ORDER BY date_sent ASC LIMIT $1 OFFSET $2',
+                'SELECT * FROM queue WHERE downloaded=false ORDER BY date_sent ASC LIMIT $1 OFFSET $2',
                 [limit, (page - 1) * limit]
             );
             return res.rows as QueueEntry[];
@@ -62,16 +62,18 @@ export class QueueModel {
     }
 
     /**
-     * Remove data from the queue.
+     * Mark data as downloaded
      *
-     * @param {string[]} idArray The ids of the to be deleted entries.
-     * @return {*} The number of deleted entries.
+     * @param {string[]} idArray The ids of the entries which shall be marked as 'downloaded'.
+     * @return {*} The number of updated entries.
      * @memberof QueueModel
      */
-    public async deleteQueueDataByIdArray(idArray: string[]): Promise<number> {
+    public async markAsDownloaded(idArray: string[]): Promise<number> {
         try {
             const pool: Pool = DB.getPool();
-            const res = await pool.query('DELETE FROM queue WHERE id = ANY($1)', [idArray]);
+            const res = await pool.query('UPDATE queue SET downloaded=true WHERE id = ANY($1)', [
+                idArray
+            ]);
             return res.rowCount;
         } catch (err) {
             Logger.Err(err);


### PR DESCRIPTION
Instead of being deleted, the response objects, which have successfully
been downloaded and decrypted, are marked as 'downloaded' in the db.

This only partially addresses #33; some functionality might still be added later on.

Also, I didn't find anything about this replaced feature in the docs for the backend. If I missed something, I'll gladly adjust the those parts.