### PR TITLE
Questionnaire versioning & retrieval

### DIFF
--- a/db/README.adoc
+++ b/db/README.adoc
@@ -29,7 +29,7 @@ To check that everything is working run `npx flyway -c db/flyway.js info` from t
 
 From the project root folder run `npx flyway -c db/flyway.js migrate` (When you run Flyway the first time, it downloads some binaries and exits. Rerun the command to start the migration.) User and password can be found in the secret database-creds.
 
-The output should look like this:
+The output should look like this (flyway an postgres versions might differ):
 [source]
 ----
 $ npx flyway -c db/flyway.js migrate
@@ -38,22 +38,24 @@ Database password:
 
 Flyway Community Edition 7.5.0 by Redgate
 Database: jdbc:database://localhost:15432/compass (PostgreSQL 12.1)
-Successfully validated 2 migrations (execution time 00:00.808s)
-Creating Schema History table "public"."flyway_schema_history" ...
-Current version of schema "public": << Empty Schema >>
-Migrating schema "public" to version "001 - Setup Tables"
+Successfully validated 6 migrations (execution time 00:00.038s)
+Current version of schema "public": 001
 Migrating schema "public" to version "002 - Initial Data"
-Successfully applied 2 migrations to schema "public" (execution time 00:20.229s)
+Migrating schema "public" to version "003 - Queue Data"
+Migrating schema "public" to version "004 - Api User"
+Migrating schema "public" to version "005 - Store Device Token"
+Migrating schema "public" to version "006 - Questionnaire Version History"
+Successfully applied 6 migrations to schema "public", now at version v006 (execution time 00:00.153s)
 ----
 
 The scripts will setup:
 
-* 5 tables
+* 6 tables
 * 1 api user (API_ID = "test", API_KEY = "gKdKLYG2g0-Y1EllI0-W")
 * 2 study participants
 * 17 exemplary queue items (you won't be able to decrypt those with your key, they are just for reference)
 
-It will not setup an examplary questionnaire. Therefore, before you can connect the mobile application to the backend, ensure that you add a questionnaire to the table called 'questionnaires'. You can find an exemplary questionnaire https://github.com/NUMde/compass-implementation-guide/blob/master/input/questionnaire-generic.json[here].
+It will not setup an exemplary questionnaire. Therefore, before you can connect the mobile application to the backend, ensure that you add a questionnaire to the table called 'questionnaires'. You can find an exemplary questionnaire https://github.com/NUMde/compass-implementation-guide/blob/master/input/questionnaire-generic.json[here].
 
 == Access DB with Admin Tool
 

--- a/db/migration/V002__Initial_Data.sql
+++ b/db/migration/V002__Initial_Data.sql
@@ -1,9 +1,3 @@
 -- Create test participant
 INSERT INTO studyparticipant (subject_id) VALUES('7bfc3b07-a97d-4e11-8ac6-b970c1745476');
 INSERT INTO studyparticipant (subject_id) VALUES('dd06747c-03df-4adb-9dbb-90b38dccab16');
--- Create test questionnaires
---Please paste your questionniare inside the ''
-INSERT INTO questionnaires (id,body) VALUES
-('initial','')
-,('q_1.0','')
-,('fedaf08b-aae2-4d9b-8306-8a3de02d2f74','');

--- a/db/migration/V006__Questionnaire_Version_History.sql
+++ b/db/migration/V006__Questionnaire_Version_History.sql
@@ -1,0 +1,11 @@
+-- Table: questionnaire_version_history
+CREATE TABLE questionnaire_version_history
+(
+    id character varying(355) NOT NULL,
+    url character varying(355) NOT NULL,
+    version character varying(355) NOT NULL,
+    name character varying(355) NOT NULL,
+    body character json NOT NULL,
+    CONSTRAINT questionnaire_version_history_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_name FOREIGN KEY (name) REFERENCES questionnaires(id)
+);

--- a/src/assets/openapi.yaml
+++ b/src/assets/openapi.yaml
@@ -48,6 +48,35 @@ paths:
             security:
                 - Bearer: []
     /questionnaire:
+        get:
+            tags:
+                - questionnaire
+            summary: Get a questionnaire by url and version
+            operationId: getQuestionnaireByUrlAndVersion
+            parameters:
+                - name: url
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: version
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+            responses:
+                '200':
+                    description: A FHIR Questionnaire as JSON
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Questionnaire'
+                '401':
+                    $ref: '#/components/responses/401NotAuthenticated'
+                '404':
+                    $ref: '#/components/responses/404NotFound'
+            security:
+                - Bearer: []
         post:
             tags:
                 - questionnaire

--- a/src/assets/openapi.yaml
+++ b/src/assets/openapi.yaml
@@ -47,6 +47,91 @@ paths:
                     $ref: '#/components/responses/500ServerError'
             security:
                 - Bearer: []
+    /questionnaire:
+        post:
+            tags:
+                - questionnaire
+            summary: Add a new questionnaire
+            operationId: addQuestionnaire
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AddOrUpdateQuestionnaireRequest'
+            parameters:
+                - name: url
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: version
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: name
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: questionnaire
+                  in: query
+                  schema:
+                    $ref: '#/components/schemas/Questionnaire'
+                  required: true
+            responses:
+                '200':
+                    description: successfully created the questionnaire
+                '401':
+                    $ref: '#/components/responses/401NotAuthenticated'
+                '409':
+                    $ref: '#/components/responses/409Conflict'
+                '500':
+                    $ref: '#/components/responses/500ServerError'
+            security:
+                - Bearer: []
+        put:
+            tags:
+                - questionnaire
+            summary: Update an existing questionnaire
+            operationId: addQuestionnaire
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AddOrUpdateQuestionnaireRequest'
+            parameters:
+                - name: url
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: version
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: name
+                  in: query
+                  schema:
+                    type: string
+                  required: true
+                - name: questionnaire
+                  in: query
+                  schema:
+                    $ref: '#/components/schemas/Questionnaire'
+                  required: true
+            responses:
+                '200':
+                    description: successfully updated the questionnaire
+                '401':
+                    $ref: '#/components/responses/401NotAuthenticated'
+                '409':
+                    $ref: '#/components/responses/409Conflict'
+                '500':
+                    $ref: '#/components/responses/500ServerError'
+            security:
+                - Bearer: []
     /queue:
         post:
             tags:
@@ -248,7 +333,7 @@ paths:
                 '401':
                     $ref: '#/components/responses/401NotAuthenticated'
                 '409':
-                    $ref: '#/components/responses/409Conflict'    
+                    $ref: '#/components/responses/409Conflict'
                 '500':
                     $ref: '#/components/responses/500ServerError'
 components:
@@ -326,10 +411,10 @@ components:
                         - on-study
                         - off-study
                     description: Marks if subject is participating in the study
-                general_study_end_date: 
+                general_study_end_date:
                     type: date
                     description: End date of study that subject is/was participating in
-                personal_study_end_date: 
+                personal_study_end_date:
                     type: date
                     description: Individual end date of study that subject is/was participating in
         Health:
@@ -345,6 +430,8 @@ components:
                 resourceType:
                     type: string
                 url:
+                    type: string
+                version:
                     type: string
                 item:
                     type: array
@@ -422,6 +509,21 @@ components:
             description: "This is the same object as `QuestionnaireItem`. Workaround for Swagger bug. Swagger can't display recursive structures. See https://github.com/swagger-api/swagger-ui/issues/3325"
             allOf:
                 - $ref: '#/components/schemas/QuestionnaireItem'
+        AddOrUpdateQuestionnaireRequest:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: the name of the questionnaire as used for the logic to deployment
+                url:
+                    type: string
+                    description: the url of the questionnaire as defined in its metadata
+                version:
+                    type: string
+                    description: the version of the questionnaire as defined in its metadata
+                questionnaire:
+                    type: object
+                    $ref: '#/components/schemas/Questionnaire'
         SubjectIdentity:
             type: object
             properties:

--- a/src/controllers/QuestionnaireController.ts
+++ b/src/controllers/QuestionnaireController.ts
@@ -6,10 +6,12 @@
 
 import { Request, Response } from 'express';
 
-import { Controller, Get, Middleware } from '@overnightjs/core';
+import { Controller, Get, Middleware, Post, Put } from '@overnightjs/core';
 
 import { QuestionnaireModel } from '../models/QuestionnaireModel';
 import { AuthorizationController } from './AuthorizationController';
+import jwt from 'express-jwt';
+import { AuthConfig } from '../config/AuthConfig';
 
 /**
  * Endpoint class for all questionnaire related restful methods.
@@ -48,6 +50,83 @@ export class QuestionnaireController {
                 } else {
                     res.status(500).end();
                 }
+            }
+        );
+    }
+
+    /**
+     * Add a questionnaire.
+     *
+     * @param {Request} req
+     * @param {Response} res
+     * @memberof QuestionnaireController
+     */
+    @Post('')
+    @Middleware(
+        jwt({
+            secret: AuthConfig.jwtSecret,
+            algorithms: ['HS256'],
+            requestProperty: 'payload',
+            isRevoked: AuthorizationController.checkApiUserLogin
+        })
+    )
+    public async addQuestionnaire(req: Request, res: Response) {
+        const url = req.body.url;
+        const version = req.body.version;
+        const name = req.body.name;
+        const questionnaire = req.body.questionnaire;
+
+        this.questionnaireModel.addQuestionnaire(url, version, name, questionnaire).then(
+            () => {
+                res.status(200).send();
+            },
+            (err) => {
+                if (err.code === '409') {
+                    res.status(409).send('A questionnaire with this name already exists.');
+                } else {
+                    res.status(500).send();
+                }
+            }
+        );
+    }
+
+    /**
+     * Update a questionnaire.
+     *
+     * @param {Request} req
+     * @param {Response} res
+     * @memberof QuestionnaireController
+     */
+    @Put('')
+    @Middleware(
+        jwt({
+            secret: AuthConfig.jwtSecret,
+            algorithms: ['HS256'],
+            requestProperty: 'payload',
+            isRevoked: AuthorizationController.checkApiUserLogin
+        })
+    )
+    public async updateQuestionnaire(req: Request, res: Response) {
+        const url = req.body.url;
+        const version = req.body.version;
+        const name = req.body.name;
+        const questionnaire = req.body.questionnaire;
+
+        this.questionnaireModel.updateQuestionnaire(url, version, name, questionnaire).then(
+            () => {
+                res.status(200).send();
+            },
+            (err) => {
+                if (err.code === 409) {
+                    res.status(409).send(
+                        'A questionnaire with this url and version already exists.'
+                    );
+                } else if (err.code === 404) {
+                    res.status(404).send(
+                        'No questionnaire with given url and name found to update'
+                    );
+                }
+                res.status(500).send();
             }
         );
     }

--- a/src/controllers/QuestionnaireController.ts
+++ b/src/controllers/QuestionnaireController.ts
@@ -130,4 +130,43 @@ export class QuestionnaireController {
             }
         );
     }
+
+    /**
+     * Update a questionnaire.
+     *
+     * @param {Request} req
+     * @param {Response} res
+     * @memberof QuestionnaireController
+     */
+    @Get('')
+    // @Middleware(
+    //     jwt({
+    //         secret: AuthConfig.jwtSecret,
+    //         algorithms: ['HS256'],
+    //         requestProperty: 'payload',
+    //         isRevoked: AuthorizationController.checkApiUserLogin
+    //     })
+    // )
+    public async getQuestionnaireByUrlAndVersion(req: Request, res: Response) {
+        let url: string, version: string;
+        try {
+            url = req.query.url.toString();
+            version = req.query.version.toString();
+        } catch (err) {
+            res.status(400).send('missing params');
+            return;
+        }
+
+        this.questionnaireModel.getQuestionnaireByUrlAndVersion(url, version).then(
+            (response) => {
+                if (response.length === 0) {
+                    res.status(404).send('questionnaire not found');
+                }
+                res.status(200).send(response[0]);
+            },
+            (error) => {
+                res.status(500).send;
+            }
+        );
+    }
 }

--- a/src/models/QuestionnaireModel.ts
+++ b/src/models/QuestionnaireModel.ts
@@ -7,6 +7,7 @@ import Logger from 'jet-logger';
 import { COMPASSConfig } from '../config/COMPASSConfig';
 import { ParticipantModel } from '../models/ParticipantModel';
 import DB from '../server/DB';
+import { IdHelper } from '../services/IdHelper';
 
 /**
  * Model class that bundles the logic for access to the questionnaire related tables.
@@ -65,6 +66,98 @@ export class QuestionnaireModel {
             Logger.Err('!!! DB might be inconsistent. Check DB !!!');
             Logger.Err(e);
             throw e;
+        } finally {
+            dbClient.release();
+        }
+    }
+
+    /**
+     * Add the questionnaire with the given id to the list of questionnaires and to the version list of all questionnaires
+     *
+     * @param {string} url the url of the questionnaire as defined in its metadata
+     * @param {string} version the version of the questionnaire as defined in its metadata
+     * @param {string} name the name of the questionnaire which also identifies it as configure in the COMPASSConfig
+     * @param {object} questionnaire the questionnaire itself as json
+     * @return {*}  {Promise<string>}
+     * @memberof QuestionnaireModel
+     */
+    public async addQuestionnaire(
+        url: string,
+        version: string,
+        name: string,
+        questionnaire: string
+    ): Promise<void> {
+        const dbClient = await DB.getPool().connect();
+        try {
+            // Make sure there isn't a questionnaire yet with the given id
+            const res = await dbClient.query('SELECT * FROM questionnaires WHERE id = $1', [name]);
+            if (res.rows.length !== 0) {
+                throw { code: 409 };
+            }
+            await dbClient.query('INSERT INTO questionnaires(id, body) VALUES($1, $2)', [
+                name,
+                questionnaire
+            ]);
+            dbClient.query('INSERT INTO questionnaire_version_history VALUES($1, $2, $3, $4, $5)', [
+                IdHelper.createID(),
+                url,
+                version,
+                name,
+                questionnaire
+            ]);
+        } catch (error) {
+            Logger.Err(error);
+            throw error;
+        } finally {
+            dbClient.release();
+        }
+    }
+
+    /**
+     * Update an existing questionnaire and add the new version to the version history.
+     *
+     * @param {string} url the url of the questionnaire as defined in its metadata
+     * @param {string} version the version of the questionnaire as defined in its metadata
+     * @param {string} name the name of the questionnaire which also identifies it as configure in the COMPASSConfig
+     * @param {object} questionnaire the questionnaire itself as json
+     * @return {*}  {Promise<string>}
+     * @memberof QuestionnaireModel
+     */
+    public async updateQuestionnaire(
+        url: string,
+        version: string,
+        name: string,
+        questionnaire: string
+    ): Promise<void> {
+        const dbClient = await DB.getPool().connect();
+        try {
+            // Make sure there is no questionnaire present with the given url and version
+            const res1 = await dbClient.query(
+                'SELECT * FROM questionnaire_version_history WHERE url = $1 AND version = $2',
+                [url, version]
+            );
+            if (res1.rows.length === 1) {
+                throw { code: 409 };
+            }
+            // Make sure there is a questionnaire with the given url and name
+            const res2 = await dbClient.query(
+                'SELECT * FROM questionnaire_version_history WHERE url = $1 AND name = $2',
+                [url, name]
+            );
+            if (res2.rows.length === 0) {
+                throw { code: 404 };
+            }
+            await dbClient.query(
+                'INSERT INTO questionnaire_version_history VALUES($1, $2, $3, $4, $5)',
+                [IdHelper.createID(), url, version, name, questionnaire]
+            );
+            dbClient.query('UPDATE questionnaires SET body = $1 WHERE id = $2 RETURNING id', [
+                questionnaire,
+                name
+            ]);
+        } catch (error) {
+            Logger.Err(error);
+            throw error;
         } finally {
             dbClient.release();
         }

--- a/src/models/QuestionnaireModel.ts
+++ b/src/models/QuestionnaireModel.ts
@@ -162,4 +162,27 @@ export class QuestionnaireModel {
             dbClient.release();
         }
     }
+
+    /**
+     * Get a questionnaire identified by url and version
+     *
+     * @param {string} url
+     * @param {string} version
+     * @returns{object} the questionnaire object
+     */
+    public async getQuestionnaireByUrlAndVersion(url: string, version: string): Promise<string[]> {
+        const dbClient = await DB.getPool().connect();
+        try {
+            const res = await dbClient.query(
+                'SELECT * FROM questionnaire_version_history WHERE url = $1 AND version = $2',
+                [url, version]
+            );
+            return res.rows;
+        } catch (error) {
+            Logger.Err(error);
+            throw error;
+        } finally {
+            dbClient.release();
+        }
+    }
 }


### PR DESCRIPTION
This pull request adds two features:

1. Versioning of questionnaires:
    A table is added which tracks the versions of all questionnaires. Endpoints are added with which new questionnaires or new versions of existing questionnaires can be added.
2. Retrieval of questionnaires by id and version:
    Questionnaires can be retrieved by passing url and version

The second part should cover PRs #38 and 52, making them obsolete.
